### PR TITLE
Add "replace" handlebars helper.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="1.9.4" date="not released">
+      <action type="add" dev="trichter">
+        Add "replace" handlebars helper.
+      </action>
       <action type="update" dev="sseifert">
         Allow custom expressions in value provider variable references.
       </action>

--- a/generator/src/main/java/io/wcm/devops/conga/generator/plugins/handlebars/helper/ReplaceHelper.java
+++ b/generator/src/main/java/io/wcm/devops/conga/generator/plugins/handlebars/helper/ReplaceHelper.java
@@ -1,0 +1,50 @@
+/*-
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2015 - 2018 wcm.io DevOps
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.devops.conga.generator.plugins.handlebars.helper;
+
+import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.helper.StringHelpers;
+import io.wcm.devops.conga.generator.spi.handlebars.HelperPlugin;
+import io.wcm.devops.conga.generator.spi.handlebars.context.HelperContext;
+
+import java.io.IOException;
+
+/**
+ * Handlebars helper that joins a list to a single string.
+ * Uses {@link StringHelpers#join}.
+ */
+public final class ReplaceHelper implements HelperPlugin<Object> {
+
+  /**
+   * Plugin/Helper name
+   */
+  public static final String NAME = "replace";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public Object apply(Object context, Options options, HelperContext pluginContext) throws IOException {
+    return StringHelpers.replace.apply(context, options);
+  }
+
+}

--- a/generator/src/main/resources/META-INF/services/io.wcm.devops.conga.generator.spi.handlebars.HelperPlugin
+++ b/generator/src/main/resources/META-INF/services/io.wcm.devops.conga.generator.spi.handlebars.HelperPlugin
@@ -6,3 +6,4 @@ io.wcm.devops.conga.generator.plugins.handlebars.helper.EnsurePropertiesHelper
 io.wcm.devops.conga.generator.plugins.handlebars.helper.IfEqualsHelper
 io.wcm.devops.conga.generator.plugins.handlebars.helper.JoinHelper
 io.wcm.devops.conga.generator.plugins.handlebars.helper.RegexQuoteHelper
+io.wcm.devops.conga.generator.plugins.handlebars.helper.ReplaceHelper

--- a/generator/src/test/java/io/wcm/devops/conga/generator/plugins/handlebars/helper/ReplaceHelperTest.java
+++ b/generator/src/test/java/io/wcm/devops/conga/generator/plugins/handlebars/helper/ReplaceHelperTest.java
@@ -1,0 +1,45 @@
+/*-
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2015 - 2018 wcm.io DevOps
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.devops.conga.generator.plugins.handlebars.helper;
+
+import com.google.common.collect.ImmutableList;
+import io.wcm.devops.conga.generator.spi.handlebars.HelperPlugin;
+import io.wcm.devops.conga.generator.util.PluginManagerImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.wcm.devops.conga.generator.plugins.handlebars.helper.TestUtils.assertHelper;
+
+public class ReplaceHelperTest {
+
+  private HelperPlugin<Object> helper;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  public void setUp() {
+    helper = new PluginManagerImpl().get(ReplaceHelper.NAME, HelperPlugin.class);
+  }
+
+  @Test
+  public void testApply() throws Exception {
+    assertHelper("subdomain_domain_tld", helper, "subdomain.domain.tld", new MockOptions(".", "_"));
+  }
+
+}


### PR DESCRIPTION
This handle bar helper is needed to replace `.` with `_` in replication agent names and can also be handy in other situations.