### PR TITLE
Enable com.github.jknack.handlebars.helper.ConditionalHelpers

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.11.6" date="not released">
+      <action type="add" dev="trichter">
+        Enable com.github.jknack.handlebars.helper.ConditionalHelpers
+      </action>
+    </release>
+
     <release version="1.11.4" date="2019-10-01">
       <action type="fix" dev="sseifert">
         Fail build when YAML contains invalid "null" elements (e.g. in tenant list).

--- a/generator/src/main/java/io/wcm/devops/conga/generator/handlebars/HandlebarsManager.java
+++ b/generator/src/main/java/io/wcm/devops/conga/generator/handlebars/HandlebarsManager.java
@@ -27,6 +27,7 @@ import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Helper;
 import com.github.jknack.handlebars.Options;
+import com.github.jknack.handlebars.helper.ConditionalHelpers;
 import com.github.jknack.handlebars.io.TemplateLoader;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -67,6 +68,9 @@ public class HandlebarsManager {
             }
           });
 
+          // register helpers
+          handlebars.registerHelpers(ConditionalHelpers.class);
+
           // register helper plugins
           pluginManager.getAll(HelperPlugin.class)
               .forEach(plugin -> handlebars.registerHelper(plugin.getName(), new Helper<Object>() {
@@ -75,6 +79,7 @@ public class HandlebarsManager {
                   return plugin.apply(context, helperOptions, helperContext);
                 }
               }));
+
 
           return handlebars;
         }

--- a/src/site/markdown/handlebars-helpers.md
+++ b/src/site/markdown/handlebars-helpers.md
@@ -2,8 +2,12 @@
 
 By using CONGA handlebars helper plugins it is possible to extend handlebars by registering custom expressions. Out of the box CONGA ships with a set of built-in custom expressions documented in this chapter. See [Extensibility model][extensibility] how to register you own helpers.
 
-The basic handlebars expressions are documented in the [Handlebars quickstart][handlebars-quickstart]. The CONGA AEM plugin also provides a set of [Custom Handlebars expressions for AEM][aem-handlebars-helpers].
+The basic handlebars expressions are documented in the [Handlebars quickstart][handlebars-quickstart].
 
+You can also use the [jknack/handlebars ConditionalHelpers](https://github.com/jknack/handlebars.java/blob/master/handlebars/src/main/java/com/github/jknack/handlebars/helper/ConditionalHelpers.java).
+
+The CONGA AEM plugin also provides a set of
+[Custom Handlebars expressions for AEM][aem-handlebars-helpers].
 
 ### regexQuote
 

--- a/src/site/markdown/handlebars-quickstart.md
+++ b/src/site/markdown/handlebars-quickstart.md
@@ -43,6 +43,7 @@ Optionally you can define an else block:
 {{/if}}
 ```
 
+You can also use the [jknack/handlebars ConditionalHelpers](https://github.com/jknack/handlebars.java/blob/master/handlebars/src/main/java/com/github/jknack/handlebars/helper/ConditionalHelpers.java).
 
 ### For each loop
 


### PR DESCRIPTION
In one project we had the need to combine several conditions. 
We ended up using

```
{{#if condition1 ~}}
{{#ifNotEquals someValue1 "" ~}}
{{#ifNotEquals someValue2 "" ~}}
# Do some stuff
{{~/ifNotEquals}}
{{~/ifNotEquals}}
{{~/if}}
```
This is obviously far away from elegant so I searched for a better solution since we do not support a "and" operand in our handlebars expressions (https://devops.wcm.io/conga/handlebars-helpers.html)

I found https://github.com/jknack/handlebars.java/blob/master/handlebars/src/main/java/com/github/jknack/handlebars/helper/ConditionalHelpers.java which is offering what we need:

```
{{#and condition1  (neq someValue1 null) (neq someValue2 null)}}
{{/and}}
```

I am not sure it the way i activated the `ConditionalHelpers.java` is correct.
What i am wondering is, why we are not already using this useful helpers and why we implemented our own helpers `ifEquals`, `ifNotEquals`.
There is also `defaultIfEmpty` where there is a existing implementation (https://javadoc.io/doc/com.github.jknack/handlebars/4.0.6/com/github/jknack/handlebars/helper/StringHelpers.html#defaultIfEmpty)