### PR TITLE
YAML model export: Avoid generating YAML alias for tenant roles arrays.

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 https://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.14.8" date="not released">
+      <action type="fix" dev="sseifert">
+        YAML model export: Avoid generating YAML alias for tenant roles arrays.
+      </action>
+    </release>
+
     <release version="1.14.6" date="2022-03-15">
       <action type="update" dev="sseifert">
         Update dependencies.

--- a/generator/src/main/java/io/wcm/devops/conga/generator/plugins/export/YamlNodeModelExport.java
+++ b/generator/src/main/java/io/wcm/devops/conga/generator/plugins/export/YamlNodeModelExport.java
@@ -141,7 +141,8 @@ public class YamlNodeModelExport implements NodeModelExportPlugin {
 
     tenantMap.put("tenant", context.getVariableStringResolver().resolve(tenantData.getTenant(), tenantData.getConfig()));
     if (!tenantData.getRoles().isEmpty()) {
-      tenantMap.put("roles", tenantData.getRoles());
+      // copy role list for each tenant to avoid alias in YAML export
+      tenantMap.put("roles", new ArrayList<>(tenantData.getRoles()));
     }
     tenantMap.put("config", context.getModelExportConfigProcessor().apply(tenantData.getConfig()));
 

--- a/tooling/conga-maven-plugin/src/it/example/verify.groovy
+++ b/tooling/conga-maven-plugin/src/it/example/verify.groovy
@@ -1,0 +1,10 @@
+
+// ensure no aliases are used in exported model YAML file
+File sevices1ModelFile = new File( basedir, "environments/target/configuration/prod/services-1/model.yaml" );
+assert sevices1ModelFile.exists();
+String sevices1Model = sevices1ModelFile.getText("utf-8");
+assert !sevices1Model.contains("&id001")
+assert !sevices1Model.contains("*id001")
+
+
+return true;


### PR DESCRIPTION
ensure no YAML alias are generated for tenant's roles string array when exporting node model.json

root cause fix for problem reported in https://github.com/wcm-io-devops/conga-aem-plugin/pull/7