### PR TITLE
disallowProperty Handlebars Expression

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 https://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.16.0" date="not released">
+      <action type="add" dev="sseifert">
+        Add new custom Handlebars expressions 'disallowProperty' which allows to block property names no longer supported.
+      </action>
+    </release>
+
     <release version="1.15.0" date="2023-03-27">
       <action type="update" dev="sseifert">
         Switch to Java 11 as minimum version.

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>io.wcm.devops.conga</groupId>
     <artifactId>io.wcm.devops.conga.parent</artifactId>
-    <version>1.15.1-SNAPSHOT</version>
+    <version>1.16.0-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>io.wcm.devops.conga</groupId>
       <artifactId>io.wcm.devops.conga.model</artifactId>
-      <version>1.15.1-SNAPSHOT</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/generator/src/main/java/io/wcm/devops/conga/generator/plugins/handlebars/helper/DisallowPropertyHelper.java
+++ b/generator/src/main/java/io/wcm/devops/conga/generator/plugins/handlebars/helper/DisallowPropertyHelper.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2023 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.devops.conga.generator.plugins.handlebars.helper;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.github.jknack.handlebars.Options;
+
+import io.wcm.devops.conga.generator.spi.handlebars.HelperPlugin;
+import io.wcm.devops.conga.generator.spi.handlebars.context.HelperContext;
+
+/**
+ * Handlebars helper that ensures a given property is not set/present.
+ * If it is, an exception is thrown with the property name.
+ * Optionally, a second parameter can be provided with a custom error message.
+ */
+public final class DisallowPropertyHelper implements HelperPlugin<Object> {
+
+  /**
+   * Plugin/Helper name
+   */
+  public static final String NAME = "disallowProperty";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public Object apply(Object context, Options options, HelperContext pluginContext) throws IOException {
+    if (isPropertyPresent(context, options)) {
+      String errorMessage = "Disallowed property is set: " + context;
+      if (options.params.length > 0 && options.params[0] != null) {
+        errorMessage = options.params[0].toString();
+      }
+      throw new IOException(errorMessage);
+    }
+    return null;
+  }
+
+  private boolean isPropertyPresent(Object propertyNameExpression, Options options) {
+    if (propertyNameExpression == null) {
+      return false;
+    }
+    String propertyName = propertyNameExpression.toString();
+    if (StringUtils.isBlank(propertyName)) {
+      return false;
+    }
+    return options.get(propertyName) != null;
+  }
+
+}

--- a/generator/src/main/resources/META-INF/services/io.wcm.devops.conga.generator.spi.handlebars.HelperPlugin
+++ b/generator/src/main/resources/META-INF/services/io.wcm.devops.conga.generator.spi.handlebars.HelperPlugin
@@ -1,4 +1,5 @@
 io.wcm.devops.conga.generator.plugins.handlebars.helper.ContainsHelper
+io.wcm.devops.conga.generator.plugins.handlebars.helper.DisallowPropertyHelper
 io.wcm.devops.conga.generator.plugins.handlebars.helper.EachIfHelper
 io.wcm.devops.conga.generator.plugins.handlebars.helper.EachIfEqualsHelper
 io.wcm.devops.conga.generator.plugins.handlebars.helper.EnsurePropertiesHelper

--- a/generator/src/test/java/io/wcm/devops/conga/generator/plugins/handlebars/helper/DisallowPropertyHelperTest.java
+++ b/generator/src/test/java/io/wcm/devops/conga/generator/plugins/handlebars/helper/DisallowPropertyHelperTest.java
@@ -1,0 +1,79 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2023 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.devops.conga.generator.plugins.handlebars.helper;
+
+import static io.wcm.devops.conga.generator.plugins.handlebars.helper.TestUtils.assertHelper;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.wcm.devops.conga.generator.spi.handlebars.HelperPlugin;
+import io.wcm.devops.conga.generator.util.PluginManagerImpl;
+
+class DisallowPropertyHelperTest {
+
+  private HelperPlugin<Object> helper;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+    helper = new PluginManagerImpl().get(DisallowPropertyHelper.NAME, HelperPlugin.class);
+  }
+
+  @Test
+  void testSetCase1() throws Exception {
+    assertThrows(IOException.class, () -> {
+      assertHelper(null, helper, "p1", new MockOptions()
+          .withProperty("p1", "v1"));
+    });
+  }
+
+  @Test
+  void testSetCase2() throws Exception {
+    IOException ex = assertThrows(IOException.class, () -> {
+      assertHelper(null, helper, "p1", new MockOptions("Custom Error Message")
+          .withProperty("p1", "v1")
+          .withProperty("p2", "v2")
+          .withProperty("p3", "v3"));
+    });
+    assertEquals("Custom Error Message", ex.getMessage());
+  }
+
+  @Test
+  void testNotSetCase1() throws Exception {
+    assertHelper(null, helper, "p1", new MockOptions());
+  }
+
+  @Test
+  void testNotSetCase2() throws Exception {
+    assertHelper(null, helper, "p1", new MockOptions("Custom Error Message"));
+  }
+
+  @Test
+  void testNotSetCase3() throws Exception {
+    assertHelper(null, helper, "p1", new MockOptions("Custom Error Message")
+        .withProperty("p2", "v1"));
+  }
+
+}

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>io.wcm.devops.conga</groupId>
     <artifactId>io.wcm.devops.conga.parent</artifactId>
-    <version>1.15.1-SNAPSHOT</version>
+    <version>1.16.0-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>io.wcm.devops.conga</groupId>
       <artifactId>io.wcm.devops.conga.resource</artifactId>
-      <version>1.15.1-SNAPSHOT</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>io.wcm.devops.conga</groupId>
   <artifactId>io.wcm.devops.conga.parent</artifactId>
-  <version>1.15.1-SNAPSHOT</version>
+  <version>1.16.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>CONGA</name>

--- a/pom.xml
+++ b/pom.xml
@@ -25,13 +25,13 @@
   <parent>
     <groupId>io.wcm.devops.conga</groupId>
     <artifactId>io.wcm.devops.conga.parent</artifactId>
-    <version>1.15.1-SNAPSHOT</version>
+    <version>1.16.0-SNAPSHOT</version>
     <relativePath>parent/pom.xml</relativePath>
   </parent>
 
   <groupId>io.wcm.devops.conga</groupId>
   <artifactId>io.wcm.devops.conga.root</artifactId>
-  <version>1.15.1-SNAPSHOT</version>
+  <version>1.16.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>CONGA</name>

--- a/resource/pom.xml
+++ b/resource/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>io.wcm.devops.conga</groupId>
     <artifactId>io.wcm.devops.conga.parent</artifactId>
-    <version>1.15.1-SNAPSHOT</version>
+    <version>1.16.0-SNAPSHOT</version>
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
 

--- a/src/site/markdown/handlebars-helpers.md.vm
+++ b/src/site/markdown/handlebars-helpers.md.vm
@@ -88,6 +88,15 @@ Ensure that all properties with the given names are set. Build fails if this is 
 ```
 
 
+${symbol_pound}${symbol_pound}${symbol_pound} disallowProperty
+
+Ensure that the given property is *not* set/present. It fails with an error message, if it is present. Optionally, a custom error message can be defined via a second parameter.
+
+```
+{{ensureProperties "group1.prop1" "Property 'group1.prop1' is deprecated, please use 'XYZ' instead."}}
+```
+
+
 
 [handlebars-quickstart]: handlebars-quickstart.html
 [extensibility]: extensibility.html

--- a/tooling/conga-cli/pom.xml
+++ b/tooling/conga-cli/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>io.wcm.devops.conga</groupId>
     <artifactId>io.wcm.devops.conga.parent</artifactId>
-    <version>1.15.1-SNAPSHOT</version>
+    <version>1.16.0-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>io.wcm.devops.conga</groupId>
       <artifactId>io.wcm.devops.conga.generator</artifactId>
-      <version>1.15.1-SNAPSHOT</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 

--- a/tooling/conga-maven-plugin/pom.xml
+++ b/tooling/conga-maven-plugin/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>io.wcm.devops.conga</groupId>
     <artifactId>io.wcm.devops.conga.parent</artifactId>
-    <version>1.15.1-SNAPSHOT</version>
+    <version>1.16.0-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
 
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>io.wcm.devops.conga</groupId>
       <artifactId>io.wcm.devops.conga.generator</artifactId>
-      <version>1.15.1-SNAPSHOT</version>
+      <version>1.16.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
Add new custom Handlebars expressions `disallowProperty` which allows to block property names no longer supported.