### PR TITLE
Increase SnakeYAML codepoint limit to 256MB (from 64MB)

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+    <release version="1.17.4" date="not-released">
+      <action type="fix" dev="trichter">
+        Increase SnakeYAML codepoint limit to 256MB (from 64MB)
+      </action>
+    </release>
+
     <release version="1.17.2" date="2025-03-31">
       <action type="update" dev="sseifert">
         Update dependencies.

--- a/model/src/main/java/io/wcm/devops/conga/model/util/YamlUtil.java
+++ b/model/src/main/java/io/wcm/devops/conga/model/util/YamlUtil.java
@@ -27,9 +27,9 @@ import org.yaml.snakeyaml.LoaderOptions;
 public final class YamlUtil {
 
   /*
-   * Increase default codepoint limit from 3MB to 64MB.
+   * Increase default codepoint limit from 3MB to 256MB.
    */
-  private static final int YAML_CODEPOINT_LIMIT = 64 * 1024 * 1024;
+  private static final int YAML_CODEPOINT_LIMIT = 256 * 1024 * 1024;
 
   private YamlUtil() {
     // static methods only


### PR DESCRIPTION
With https://github.com/wcm-io-devops/conga/pull/47 we already increased the codepoint limit to 64 MB.
Now we even hit this target in one of the projects.
So I increase the codepoint limit to 256MB with this PR.