### PR TITLE
add support for merging maps with key property

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,8 +24,8 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
-   <release version="1.19.0" date="not released" issue="149">
-      <action type="add" dev="bsommerfeld">
+   <release version="1.19.0" date="not released">
+      <action type="add" dev="bsommerfeld" issue="149">
         Support deep merge of list entries with 'key' field: When merging lists with map objects containing a 'key' field, entries with the same key are now merged instead of replaced, preserving fields from base configuration that are not overridden in variants.
       </action>
     </release>

--- a/changes.xml
+++ b/changes.xml
@@ -24,7 +24,7 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
-   <release version="1.18.1" date="2023-10-20">
+   <release version="1.19.0" date="not released" issue="149">
       <action type="add" dev="bsommerfeld">
         Support deep merge of list entries with 'key' field: When merging lists with map objects containing a 'key' field, entries with the same key are now merged instead of replaced, preserving fields from base configuration that are not overridden in variants.
       </action>

--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/2.0.0 https://maven.apache.org/xsd/changes-2.0.0.xsd">
   <body>
 
+   <release version="1.18.1" date="2023-10-20">
+      <action type="add" dev="bsommerfeld">
+        Support deep merge of list entries with 'key' field: When merging lists with map objects containing a 'key' field, entries with the same key are now merged instead of replaced, preserving fields from base configuration that are not overridden in variants.
+      </action>
+    </release>
+
     <release version="1.18.0" date="2025-09-25">
       <action type="update" dev="sseifert">
         Switch to Java 17.

--- a/model/src/main/java/io/wcm/devops/conga/model/util/MergingList.java
+++ b/model/src/main/java/io/wcm/devops/conga/model/util/MergingList.java
@@ -19,9 +19,9 @@
  */
 package io.wcm.devops.conga.model.util;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
-import java.util.HashMap;
 
 /**
  * Special list that marks a list as "mergeable" in downstream and preservers the merge position.
@@ -54,7 +54,7 @@ final class MergingList<T> extends LinkedList<T> {
       }
     }
     else {
-      this.addIgnoreDuplicates(item);
+      this.addIgnoreDuplicates(Integer.MAX_VALUE, item);
     }
   }
 
@@ -75,24 +75,8 @@ final class MergingList<T> extends LinkedList<T> {
       return false;
     }
     else {
-      return this.addIgnoreDuplicates(item);
+      return this.addIgnoreDuplicates(Integer.MAX_VALUE, item);
     }
-  }
-
-  private boolean addIgnoreDuplicates(T item) {
-    // Check for key-based duplicate in case of Map objects with "key" field
-    int existingIndex = findIndexByKey(item);
-    if (existingIndex >= 0) {
-      // Item with same key already exists - merge the maps
-      mergeItemAtIndex(existingIndex, item);
-      return false;
-    }
-    // Standard duplicate check
-    if (!this.contains(item)) {
-      super.add(item);
-      return true;
-    }
-    return false;
   }
 
   private boolean addIgnoreDuplicates(int index, T item) {
@@ -130,12 +114,12 @@ final class MergingList<T> extends LinkedList<T> {
     if (existingItem instanceof Map && newItem instanceof Map) {
       Map<Object, Object> existingMap = (Map<Object, Object>)existingItem;
       Map<?, ?> newMap = (Map<?, ?>)newItem;
-      
+
       // Merge: Start with new (base), then override with existing (variant)
       // This preserves fields from base that are not in variant
       Map<Object, Object> mergedMap = new HashMap<>(newMap);
       mergedMap.putAll(existingMap);
-      
+
       super.set(index, (T)mergedMap);
     }
     // For non-Map objects, keep the existing one
@@ -148,7 +132,6 @@ final class MergingList<T> extends LinkedList<T> {
    * @param item Item to check
    * @return Index of existing item with same key, or -1 if not found
    */
-  @SuppressWarnings("unchecked")
   private int findIndexByKey(T item) {
     if (!(item instanceof Map)) {
       return -1;
@@ -158,7 +141,7 @@ final class MergingList<T> extends LinkedList<T> {
     if (itemKey == null) {
       return -1;
     }
-    
+
     for (int i = 0; i < this.size(); i++) {
       T existing = this.get(i);
       if (existing instanceof Map) {

--- a/model/src/main/java/io/wcm/devops/conga/model/util/MergingList.java
+++ b/model/src/main/java/io/wcm/devops/conga/model/util/MergingList.java
@@ -21,6 +21,7 @@ package io.wcm.devops.conga.model.util;
 
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.HashMap;
 
 /**
  * Special list that marks a list as "mergeable" in downstream and preservers the merge position.
@@ -132,7 +133,7 @@ final class MergingList<T> extends LinkedList<T> {
       
       // Merge: Start with new (base), then override with existing (variant)
       // This preserves fields from base that are not in variant
-      Map<Object, Object> mergedMap = new java.util.HashMap<>(newMap);
+      Map<Object, Object> mergedMap = new HashMap<>(newMap);
       mergedMap.putAll(existingMap);
       
       super.set(index, (T)mergedMap);

--- a/model/src/main/java/io/wcm/devops/conga/model/util/MergingList.java
+++ b/model/src/main/java/io/wcm/devops/conga/model/util/MergingList.java
@@ -20,6 +20,7 @@
 package io.wcm.devops.conga.model.util;
 
 import java.util.LinkedList;
+import java.util.Map;
 
 /**
  * Special list that marks a list as "mergeable" in downstream and preservers the merge position.
@@ -78,6 +79,14 @@ final class MergingList<T> extends LinkedList<T> {
   }
 
   private boolean addIgnoreDuplicates(T item) {
+    // Check for key-based duplicate in case of Map objects with "key" field
+    int existingIndex = findIndexByKey(item);
+    if (existingIndex >= 0) {
+      // Item with same key already exists - merge the maps
+      mergeItemAtIndex(existingIndex, item);
+      return false;
+    }
+    // Standard duplicate check
     if (!this.contains(item)) {
       super.add(item);
       return true;
@@ -86,6 +95,14 @@ final class MergingList<T> extends LinkedList<T> {
   }
 
   private boolean addIgnoreDuplicates(int index, T item) {
+    // Check for key-based duplicate in case of Map objects with "key" field
+    int existingIndex = findIndexByKey(item);
+    if (existingIndex >= 0) {
+      // Item with same key already exists - merge the maps
+      mergeItemAtIndex(existingIndex, item);
+      return false;
+    }
+    // Standard duplicate check
     if (!this.contains(item)) {
       if (index > this.size() - 1) {
         super.add(item);
@@ -96,6 +113,62 @@ final class MergingList<T> extends LinkedList<T> {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Merges a new item into an existing item at the given index.
+   * For Map objects, performs a deep merge where the existing item takes precedence.
+   * This is because the existing item is typically from a variant (higher priority),
+   * and the new item is from a base config (lower priority).
+   * @param index Index of existing item
+   * @param newItem New item to merge in
+   */
+  @SuppressWarnings("unchecked")
+  private void mergeItemAtIndex(int index, T newItem) {
+    T existingItem = this.get(index);
+    if (existingItem instanceof Map && newItem instanceof Map) {
+      Map<Object, Object> existingMap = (Map<Object, Object>)existingItem;
+      Map<?, ?> newMap = (Map<?, ?>)newItem;
+      
+      // Merge: Start with new (base), then override with existing (variant)
+      // This preserves fields from base that are not in variant
+      Map<Object, Object> mergedMap = new java.util.HashMap<>(newMap);
+      mergedMap.putAll(existingMap);
+      
+      super.set(index, (T)mergedMap);
+    }
+    // For non-Map objects, keep the existing one
+    // (do nothing, existing item has higher priority)
+  }
+
+  /**
+   * Finds an existing item in the list that has the same "key" value as the given item.
+   * This applies only to Map objects that contain a "key" field.
+   * @param item Item to check
+   * @return Index of existing item with same key, or -1 if not found
+   */
+  @SuppressWarnings("unchecked")
+  private int findIndexByKey(T item) {
+    if (!(item instanceof Map)) {
+      return -1;
+    }
+    Map<?, ?> itemMap = (Map<?, ?>)item;
+    Object itemKey = itemMap.get("key");
+    if (itemKey == null) {
+      return -1;
+    }
+    
+    for (int i = 0; i < this.size(); i++) {
+      T existing = this.get(i);
+      if (existing instanceof Map) {
+        Map<?, ?> existingMap = (Map<?, ?>)existing;
+        Object existingKey = existingMap.get("key");
+        if (itemKey.equals(existingKey)) {
+          return i;
+        }
+      }
+    }
+    return -1;
   }
 
   /**

--- a/model/src/test/java/io/wcm/devops/conga/model/util/MapMergerTest.java
+++ b/model/src/test/java/io/wcm/devops/conga/model/util/MapMergerTest.java
@@ -265,6 +265,127 @@ class MapMergerTest {
             map("k1", list(map("p2", "v2"), map("p3", "v3")))));
   }
 
+  @Test
+  void testMergeList_KeyValueObjects_Override() {
+    // Test case for key-value objects: objects with same "key" should merge
+    Map<String, Object> baseConfig = map(
+        "key", "magnolia.bootstrap.dir",
+        "value", "WEB-INF/bootstrap/author WEB-INF/bootstrap/common",
+        "comment", "the directories in which the bootstrap files are searched"
+    );
+    
+    Map<String, Object> variantConfig = map(
+        "key", "magnolia.bootstrap.dir",
+        "value", "C:/user/test/dir"
+    );
+    
+    // When merging with _merge_ token, variant values override base values, but base fields are preserved
+    Map<String, Object> result = merge(
+        map("proj.magnolia.cms.properties", list(LIST_MERGE_ENTRY, variantConfig)),
+        map("proj.magnolia.cms.properties", list(baseConfig))
+    );
+    
+    // Should have only one entry with merged values: value from variant, comment from base
+    List<Object> resultList = (List<Object>)result.get("proj.magnolia.cms.properties");
+    assertEquals(1, resultList.size());
+    
+    Map<String, Object> expectedMerged = map(
+        "key", "magnolia.bootstrap.dir",
+        "value", "C:/user/test/dir",
+        "comment", "the directories in which the bootstrap files are searched"
+    );
+    assertEquals(expectedMerged, resultList.get(0));
+  }
+
+  @Test
+  void testMergeList_KeyValueObjects_OverrideComment() {
+    // Test that comment can be explicitly overridden if provided in variant
+    Map<String, Object> baseConfig = map(
+        "key", "magnolia.bootstrap.dir",
+        "value", "WEB-INF/bootstrap/author WEB-INF/bootstrap/common",
+        "comment", "old comment"
+    );
+    
+    Map<String, Object> variantConfig = map(
+        "key", "magnolia.bootstrap.dir",
+        "value", "woanders",
+        "comment", "new comment"
+    );
+    
+    Map<String, Object> result = merge(
+        map("props", list(LIST_MERGE_ENTRY, variantConfig)),
+        map("props", list(baseConfig))
+    );
+    
+    // Comment should be overridden because it was explicitly provided in variant
+    List<Object> resultList = (List<Object>)result.get("props");
+    assertEquals(1, resultList.size());
+    assertEquals(variantConfig, resultList.get(0));
+  }
+
+  @Test
+  void testMergeList_KeyValueObjects_MultipleKeys() {
+    // Test with multiple different keys - they should all be preserved
+    Map<String, Object> config1 = map(
+        "key", "prop1",
+        "value", "value1"
+    );
+    
+    Map<String, Object> config2 = map(
+        "key", "prop2",
+        "value", "value2"
+    );
+    
+    Map<String, Object> config3 = map(
+        "key", "prop3",
+        "value", "value3"
+    );
+    
+    Map<String, Object> result = merge(
+        map("props", list(LIST_MERGE_ENTRY, config3)),
+        map("props", list(config1, config2))
+    );
+    
+    // Should have all three entries
+    // When LIST_MERGE_ENTRY is at start of l1, l2 elements are inserted at the beginning
+    // Result: [config1, config2, config3]
+    List<Object> resultList = (List<Object>)result.get("props");
+    assertEquals(3, resultList.size());
+    assertEquals(config1, resultList.get(0));
+    assertEquals(config2, resultList.get(1));
+    assertEquals(config3, resultList.get(2));
+  }
+
+  @Test
+  void testMergeList_KeyValueObjects_MixedOverrideAndNew() {
+    // Test with mix of overriding and new keys
+    Map<String, Object> config1 = map("key", "prop1", "value", "value1", "comment", "comment1");
+    Map<String, Object> config2 = map("key", "prop2", "value", "value2", "comment", "comment2");
+    Map<String, Object> config2Override = map("key", "prop2", "value", "value2-override");
+    Map<String, Object> config3 = map("key", "prop3", "value", "value3");
+    
+    Map<String, Object> result = merge(
+        map("props", list(LIST_MERGE_ENTRY, config2Override, config3)),
+        map("props", list(config1, config2))
+    );
+    
+    // l1 = [LIST_MERGE_ENTRY, config2Override, config3] -> MergingList = [config2Override, config3] with mergePos=0
+    // l2 = [config1, config2]
+    // When adding l2:
+    //   - config1 is inserted at position 0 -> [config1, config2Override, config3]
+    //   - config2 is merged into config2Override, preserving comment from config2
+    // Result: [config1, merged(config2, config2Override), config3]
+    List<Object> resultList = (List<Object>)result.get("props");
+    assertEquals(3, resultList.size());
+    assertEquals(config1, resultList.get(0));
+    
+    // config2Override should have merged with config2, keeping comment from config2
+    Map<String, Object> expectedConfig2Merged = map("key", "prop2", "value", "value2-override", "comment", "comment2");
+    assertEquals(expectedConfig2Merged, resultList.get(1));
+    
+    assertEquals(config3, resultList.get(2));
+  }
+
   private static List<Object> list(Object... items) {
     return Arrays.asList(items);
   }

--- a/model/src/test/java/io/wcm/devops/conga/model/util/MapMergerTest.java
+++ b/model/src/test/java/io/wcm/devops/conga/model/util/MapMergerTest.java
@@ -266,6 +266,7 @@ class MapMergerTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void testMergeList_KeyValueObjects_Override() {
     // Test case for key-value objects: objects with same "key" should merge
     Map<String, Object> baseConfig = map(
@@ -273,22 +274,22 @@ class MapMergerTest {
         "value", "WEB-INF/bootstrap/author WEB-INF/bootstrap/common",
         "comment", "the directories in which the bootstrap files are searched"
     );
-    
+
     Map<String, Object> variantConfig = map(
         "key", "magnolia.bootstrap.dir",
         "value", "C:/user/test/dir"
     );
-    
+
     // When merging with _merge_ token, variant values override base values, but base fields are preserved
     Map<String, Object> result = merge(
         map("proj.magnolia.cms.properties", list(LIST_MERGE_ENTRY, variantConfig)),
         map("proj.magnolia.cms.properties", list(baseConfig))
     );
-    
+
     // Should have only one entry with merged values: value from variant, comment from base
     List<Object> resultList = (List<Object>)result.get("proj.magnolia.cms.properties");
     assertEquals(1, resultList.size());
-    
+
     Map<String, Object> expectedMerged = map(
         "key", "magnolia.bootstrap.dir",
         "value", "C:/user/test/dir",
@@ -298,6 +299,7 @@ class MapMergerTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void testMergeList_KeyValueObjects_OverrideComment() {
     // Test that comment can be explicitly overridden if provided in variant
     Map<String, Object> baseConfig = map(
@@ -305,18 +307,18 @@ class MapMergerTest {
         "value", "WEB-INF/bootstrap/author WEB-INF/bootstrap/common",
         "comment", "old comment"
     );
-    
+
     Map<String, Object> variantConfig = map(
         "key", "magnolia.bootstrap.dir",
         "value", "woanders",
         "comment", "new comment"
     );
-    
+
     Map<String, Object> result = merge(
         map("props", list(LIST_MERGE_ENTRY, variantConfig)),
         map("props", list(baseConfig))
     );
-    
+
     // Comment should be overridden because it was explicitly provided in variant
     List<Object> resultList = (List<Object>)result.get("props");
     assertEquals(1, resultList.size());
@@ -324,28 +326,29 @@ class MapMergerTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void testMergeList_KeyValueObjects_MultipleKeys() {
     // Test with multiple different keys - they should all be preserved
     Map<String, Object> config1 = map(
         "key", "prop1",
         "value", "value1"
     );
-    
+
     Map<String, Object> config2 = map(
         "key", "prop2",
         "value", "value2"
     );
-    
+
     Map<String, Object> config3 = map(
         "key", "prop3",
         "value", "value3"
     );
-    
+
     Map<String, Object> result = merge(
         map("props", list(LIST_MERGE_ENTRY, config3)),
         map("props", list(config1, config2))
     );
-    
+
     // Should have all three entries
     // When LIST_MERGE_ENTRY is at start of l1, l2 elements are inserted at the beginning
     // Result: [config1, config2, config3]
@@ -357,18 +360,19 @@ class MapMergerTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void testMergeList_KeyValueObjects_MixedOverrideAndNew() {
     // Test with mix of overriding and new keys
     Map<String, Object> config1 = map("key", "prop1", "value", "value1", "comment", "comment1");
     Map<String, Object> config2 = map("key", "prop2", "value", "value2", "comment", "comment2");
     Map<String, Object> config2Override = map("key", "prop2", "value", "value2-override");
     Map<String, Object> config3 = map("key", "prop3", "value", "value3");
-    
+
     Map<String, Object> result = merge(
         map("props", list(LIST_MERGE_ENTRY, config2Override, config3)),
         map("props", list(config1, config2))
     );
-    
+
     // l1 = [LIST_MERGE_ENTRY, config2Override, config3] -> MergingList = [config2Override, config3] with mergePos=0
     // l2 = [config1, config2]
     // When adding l2:
@@ -378,11 +382,11 @@ class MapMergerTest {
     List<Object> resultList = (List<Object>)result.get("props");
     assertEquals(3, resultList.size());
     assertEquals(config1, resultList.get(0));
-    
+
     // config2Override should have merged with config2, keeping comment from config2
     Map<String, Object> expectedConfig2Merged = map("key", "prop2", "value", "value2-override", "comment", "comment2");
     assertEquals(expectedConfig2Merged, resultList.get(1));
-    
+
     assertEquals(config3, resultList.get(2));
   }
 

--- a/src/site/markdown/yaml-definitions.md
+++ b/src/site/markdown/yaml-definitions.md
@@ -105,7 +105,7 @@ Inheritance order (higher number has higher precedence):
 7. Variant configuration from node
 8. Configuration from multiply plugins, e.g. the tenant-specific configuration
 
-There is a special support when merging list parameter. By default a list value on a deeper lever overwrites a list inherited from a parameter map on a higher level completely. If you insert the keyword `_merge_` as list item on either of the list values, they are merged and the special keyword entry is removed.
+There is a special support when merging list parameter. By default a list value on a deeper lever overwrites a list inherited from a parameter map on a higher level completely. If you insert the keyword `_merge_` as list item on either of the list values, they are merged and the special keyword entry is removed. If a merged list contains child objects with `key` properties, merging logic checks for the keys and merges the list as key-value list.
 
 
 ### Variable references


### PR DESCRIPTION
On a customer project, I needed to create templates on key=value base and was not able to merge entries over roles, inheritiances and variants without resulting in several duplicate entries. Since conga was basically calling to string on each element of the list and adding each entry towards it, no matter the key was contained or not. 

With this extention, the conga MergingList Model is now capable to merge lists with key value Entries e.g:
`
config:
  properties:
  - key: key1
    value: value1
  - key: key2
    value: value2

+

config:
  properties:
  - _merge_
  - key: key3
    value: value3
  - key: key2
    value: new-value

=

config:
  properties:
  - key: key1
    value: value1
  - key: key3
    value: value3
  - key: key2
    value: new-value
`
  
